### PR TITLE
Clean up architecture.md by removing extra lines

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -168,10 +168,6 @@ All UML diagrams were created in Excalidraw.
 
 Editable source board: ```
 ../diagrams/shell_design.excalidraw
-```
-
-
-
 ---
 
 # 8. Conclusion


### PR DESCRIPTION
Removed unnecessary whitespace and comments from the architecture document.