### PR TITLE
Added I/O Redirection, Refactored command parsing

### DIFF
--- a/include/command/command.hpp
+++ b/include/command/command.hpp
@@ -2,13 +2,20 @@
 #include <string>
 #include <vector>
 
+struct Redirection {
+    std::string operand;
+    std::string fileDesc;
+};
 class Command {
-private:
-  std::string program;
-  std::vector<std::string> arguments;
+  private:
+    std::string program;
+    std::vector<std::string> arguments;
+    std::vector<Redirection> redirection;
 
-public:
-  Command(std::string program, std::vector<std::string> arguments);
-  const std::string &getProgram() const;
-  const std::vector<std::string> &getArguments() const;
+  public:
+    Command(std::string program, std::vector<std::string> arguments,
+            std::vector<Redirection> redirection);
+    const std::string &getProgram() const;
+    const std::vector<std::string> &getArguments() const;
+    const std::vector<Redirection> &getRedirection() const;
 };

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -1,10 +1,16 @@
 #include "command/command.hpp"
 
-Command::Command(std::string program, std::vector<std::string> arguments)
-    : program(std::move(program)), arguments(std::move(arguments)) {}
+Command::Command(std::string program, std::vector<std::string> arguments,
+                 std::vector<Redirection> redirection)
+    : program(std::move(program)), arguments(std::move(arguments)),
+      redirection(std::move(redirection)) {}
 
 const std::string &Command::getProgram() const { return program; }
 
 const std::vector<std::string> &Command::getArguments() const {
-  return arguments;
+    return arguments;
+}
+
+const std::vector<Redirection> &Command::getRedirection() const {
+    return redirection;
 }

--- a/src/executor/executor.cpp
+++ b/src/executor/executor.cpp
@@ -1,49 +1,100 @@
 #include "executor/executor.hpp"
 #include "command/command.hpp"
 #include <cstdlib>
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 Executor::Executor(Builtins *builtin) : builtin(builtin) {}
 
 void Executor::execute(Command &cmd) {
-  // Check it the cmd is builtin if yes then executeBuiltin else executeExternal
+    // Check it the cmd is builtin if yes then executeBuiltin else
+    // executeExternal
 
-  if (builtin->isBuiltin(cmd.getProgram())) {
-    executeBuiltin(cmd);
-  } else {
-    executeExternal(cmd);
-  }
+    if (builtin->isBuiltin(cmd.getProgram())) {
+        executeBuiltin(cmd);
+    } else {
+        executeExternal(cmd);
+    }
 }
 void Executor::executeBuiltin(Command &cmd) { builtin->dispatch(cmd); }
 
 void Executor::executeExternal(Command &cmd) {
-  pid_t pid = fork();
-  if (pid < 0) {
-    perror("fork");
-    return;
-  }
-  if (pid == 0) {
-    // Child will call the execvp and executes the command + arguments
-    // for execvp we need to convert the arguments to char* [] and it should
-    // end with a NULL and the arr[0] will have the command
-    auto &name = cmd.getProgram();
-    auto &arg = cmd.getArguments();
-
-    std::vector<char *> argv;
-    argv.push_back(const_cast<char *>(name.c_str()));
-
-    for (const auto &s : arg) {
-      argv.push_back(const_cast<char *>(s.c_str()));
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return;
     }
-    argv.push_back(nullptr);
+    if (pid == 0) {
+        // Child will call the execvp and executes the command + arguments
+        // for execvp we need to convert the arguments to char* [] and it should
+        // end with a NULL and the arr[0] will have the command
+        auto &name = cmd.getProgram();
+        auto &arg = cmd.getArguments();
+        auto &redirection = cmd.getRedirection();
 
-    // only return on failure
-    execvp(argv[0], argv.data());
-    perror("execvp");
-    _exit(EXIT_FAILURE);
+        for (auto &r : redirection) {
+            // NOTE: 0644 is the standard permission (owner read/write,
+            // group/others read). Without it, the created file gets random
+            // permissions since the third argument is unspecified.
+            // For "<" the file already exist so no need.
+            if (r.operand == "<") {
+                // open with O_RDONLY, dup2 to fd 0
+                int ffd = open(r.fileDesc.c_str(), O_RDONLY);
+                if (ffd == -1) {
+                    perror("open");
+                    _exit(EXIT_FAILURE);
+                }
 
-  } else {
-    waitpid(pid, nullptr, 0);
-  }
+                dup2(ffd, 0);
+                close(ffd);
+            } else if (r.operand == ">") {
+                // open with O_WRONLY | O_CREAT | O_TRUNC, dup2 to fd 1
+                int ffd = open(r.fileDesc.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
+                               0644);
+                if (ffd == -1) {
+                    perror("open");
+                    _exit(EXIT_FAILURE);
+                }
+                dup2(ffd, 1);
+                close(ffd);
+            } else if (r.operand == ">>") {
+                // open with O_WRONLY | O_CREAT | O_APPEND, dup2 to fd 1
+                int ffd = open(r.fileDesc.c_str(),
+                               O_WRONLY | O_APPEND | O_CREAT, 0644);
+                if (ffd == -1) {
+                    perror("open");
+                    _exit(EXIT_FAILURE);
+                }
+                dup2(ffd, 1);
+                close(ffd);
+
+            } else if (r.operand == "2>") {
+                // open with O_WRONLY | O_CREAT | O_TRUNC, dup2 to fd 2
+                int ffd = open(r.fileDesc.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
+                               0644);
+                if (ffd == -1) {
+                    perror("open");
+                    _exit(EXIT_FAILURE);
+                }
+                dup2(ffd, 2);
+                close(ffd);
+            }
+        }
+        std::vector<char *> argv;
+        argv.push_back(const_cast<char *>(name.c_str()));
+
+        for (const auto &s : arg) {
+            argv.push_back(const_cast<char *>(s.c_str()));
+        }
+        argv.push_back(nullptr);
+
+        // only return on failure
+        execvp(argv[0], argv.data());
+        perror("execvp");
+        _exit(EXIT_FAILURE);
+
+    } else {
+        waitpid(pid, nullptr, 0);
+    }
 }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -1,20 +1,32 @@
 #include "parser/parser.hpp"
 #include <sstream>
 std::optional<Command> Parser::parse(const std::string &input) const {
-  std::stringstream ss(input);
-  std::string token;
-  std::vector<std::string> tokens;
+    std::stringstream ss(input);
+    std::string token;
+    std::vector<std::string> tokens;
+    std::vector<Redirection> redirection;
 
-  while (ss >> token) {
-    tokens.push_back(token);
-  }
-  if (tokens.empty()) {
-    return std::nullopt;
-  }
+    // HACK: We can use the arguments and then parse from there?
+    while (ss >> token) {
+        // If token contains operand seperate from arguments
+        if (token == "<" || token == ">" || token == ">>" || token == "2>") {
+            Redirection r;
+            // First is the operand
+            r.operand = token;
+            // Next the fileName
+            ss >> r.fileDesc;
+            redirection.push_back(r);
+        } else {
+            tokens.push_back(token);
+        }
+    }
+    if (tokens.empty()) {
+        return std::nullopt;
+    }
 
-  std::string program = tokens[0];
+    std::string program = tokens[0];
 
-  std::vector<std::string> arguments(tokens.begin() + 1, tokens.end());
+    std::vector<std::string> arguments(tokens.begin() + 1, tokens.end());
 
-  return Command(program, arguments);
+    return Command(program, arguments, redirection);
 }


### PR DESCRIPTION
Add I/O redirection support
Refactored command parsing to separate redirection operators from arguments. During tokenization, <, >, >>, and 2> tokens are now extracted into a dedicated Redirection struct vector instead of being mixed into the args vector, keeping the args clean for execvp.
In the executor, the child process loops over redirections before execvp — opening the target file with appropriate flags and using dup2 to rewire the relevant file descriptor (stdin/stdout/stderr) before handing off to the program.
Supported operators:

< — stdin from file
> — stdout to file (overwrite)
>> — stdout to file (append)
2> — stderr to file