### PR TITLE
fix: check dup2 values, replace magic number - fixes #13

### DIFF
--- a/src/executor/executor.cpp
+++ b/src/executor/executor.cpp
@@ -39,45 +39,62 @@ void Executor::executeExternal(Command &cmd) {
             // permissions since the third argument is unspecified.
             // For "<" the file already exist so no need.
             if (r.operand == "<") {
-                // open with O_RDONLY, dup2 to fd 0
+                // open with O_RDONLY, dup2 to fd 0 - STDIN_FILENO
                 int ffd = open(r.fileDesc.c_str(), O_RDONLY);
                 if (ffd == -1) {
                     perror("open");
                     _exit(EXIT_FAILURE);
                 }
 
-                dup2(ffd, 0);
+                if (dup2(ffd, STDIN_FILENO) == -1) {
+                    perror("dup2");
+                    _exit(EXIT_FAILURE);
+                }
                 close(ffd);
             } else if (r.operand == ">") {
-                // open with O_WRONLY | O_CREAT | O_TRUNC, dup2 to fd 1
+                // open with O_WRONLY | O_CREAT | O_TRUNC, dup2 to fd 1 -
+                // STDOUT_FILENO
                 int ffd = open(r.fileDesc.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
                                0644);
                 if (ffd == -1) {
                     perror("open");
                     _exit(EXIT_FAILURE);
                 }
-                dup2(ffd, 1);
+
+                if (dup2(ffd, STDOUT_FILENO) == -1) {
+                    perror("dup2");
+                    _exit(EXIT_FAILURE);
+                }
                 close(ffd);
             } else if (r.operand == ">>") {
-                // open with O_WRONLY | O_CREAT | O_APPEND, dup2 to fd 1
+                // open with O_WRONLY | O_CREAT | O_APPEND, dup2 to fd 1 -
+                // STDOUT_FILENO
                 int ffd = open(r.fileDesc.c_str(),
                                O_WRONLY | O_APPEND | O_CREAT, 0644);
                 if (ffd == -1) {
                     perror("open");
                     _exit(EXIT_FAILURE);
                 }
-                dup2(ffd, 1);
+
+                if (dup2(ffd, STDOUT_FILENO) == -1) {
+                    perror("dup2");
+                    _exit(EXIT_FAILURE);
+                }
                 close(ffd);
 
             } else if (r.operand == "2>") {
-                // open with O_WRONLY | O_CREAT | O_TRUNC, dup2 to fd 2
+                // open with O_WRONLY | O_CREAT | O_TRUNC, dup2 to fd 2 -
+                // STDERR_FILENO
                 int ffd = open(r.fileDesc.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
                                0644);
                 if (ffd == -1) {
                     perror("open");
                     _exit(EXIT_FAILURE);
                 }
-                dup2(ffd, 2);
+                if (dup2(ffd, STDERR_FILENO) == -1) {
+                    perror("dup2");
+                    _exit(EXIT_FAILURE);
+                }
                 close(ffd);
             }
         }


### PR DESCRIPTION
Fix : dup2 value checking 
Replaced magic number 0, 1, 2 with their standard file description convention.